### PR TITLE
Use mozilla's upstream deb package

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -39,10 +39,6 @@ jobs:
           echo "tag-name=${{ env.VYOS_VERSION }}-${build_date}" >> "$GITHUB_OUTPUT"
           echo "iso-name=${{ env.VYOS_VERSION }}-${build_date}-${{ env.VYOS_ARCH }}" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Tools
-        run: |
-          sudo apt install -y alien
-
       - name: Clone vyos-build
         run: git clone -b ${{ env.VYOS_BRANCH }} --single-branch ${{ env.VYOS_URL }}
 
@@ -54,19 +50,13 @@ jobs:
           fileName: "*amd64.deb"
           out-file-path: vyos-build/packages
 
-      - name: Download SOPS rpm
+      - name: Download SOPS
         uses: robinraju/release-downloader@768b85c8d69164800db5fc00337ab917daf3ce68 # v1.7
         with:
           repository: mozilla/sops
           latest: true
-          fileName: "*x86_64.rpm"
+          fileName: "*amd64.deb"
           out-file-path: vyos-build/packages
-
-      - name: Convert any RPMs to DEBs
-        working-directory: vyos-build/packages
-        run: |
-          sudo alien --to-deb *.rpm
-          rm -rf *.rpm
 
       - name: Configure
         working-directory: vyos-build


### PR DESCRIPTION
as discussed in discord, mozilla provides a `.deb`, so we can just use that.

tested by building and booting a vm with the iso.